### PR TITLE
Ni2PointCloud: fix include path to locate OpenNI.h

### DIFF
--- a/Ni2PointCloud/Makefile
+++ b/Ni2PointCloud/Makefile
@@ -1,6 +1,6 @@
 PWD = $(shell pwd)
 SRC = ./Ni2PointCloud.cpp
-CPPFLAGS = -std=c++11 -g -Dlinux -I/usr/include/openni2
+CPPFLAGS = -std=c++11 -g -Dlinux -I../../Include
 LDFLAGS = -L$(PWD) -Wl,-rpath ./ -lOpenNI2
 
 # OpenCV

--- a/README.md
+++ b/README.md
@@ -96,6 +96,14 @@ cp ../../Tools/OpenNI2/Drivers/libmodule-lips2.so OpenNI2/Drivers/
 CXX=g++ make
 ```
 
+##### Ni2PointCloud #####
+```
+cd LIPS_Sample/Ni2PointCloud
+cp -r ../../Redist/* .
+cp ../../Tools/OpenNI2/Drivers/libmodule-lips2.so OpenNI2/Drivers/
+CXX=g++ make
+```
+
 #### Build your own application ####
 You can base the samples we provided to develop your own application. What you need to know are:
 


### PR DESCRIPTION
Also add build instruction for Ni2PointCloud

Bugzilla-Id: